### PR TITLE
Single conversion fixed / returning a int pointer array

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # ADS1120 Arduino Library
 
 Arduino/C++ Driver for the ADS1220 24-bit Analog to Digital Converter.
+
+This library also works with ADS1120 from TI

--- a/examples/ADS1220_Demo/ByteArrayExample.ino
+++ b/examples/ADS1220_Demo/ByteArrayExample.ino
@@ -1,0 +1,29 @@
+#include "ADS1220.h"
+
+ADS1220 adc;
+
+long adc_reading;
+
+void setup() {
+  Serial.begin(115200);
+
+  adc.begin();
+  adc.setConversionMode(0x01);
+  adc.setDataRate(0x00);
+}
+
+void loop() {
+  if (adc.isDataReady()){
+    byte * point;
+    point = adc.readADC_Array();
+    
+    long adcVal = * point;
+    adcVal = (adcVal << 8) | *(point + 1);
+    adcVal = (adcVal << 8) | *(point + 2);
+  
+    adcVal = ( adcVal << 8 );
+    adcVal = ( adcVal >> 8 );
+    
+    Serial.println(adcVal);
+  }
+}

--- a/examples/ADS1220_Demo/SingleConversion.ino
+++ b/examples/ADS1220_Demo/SingleConversion.ino
@@ -1,0 +1,29 @@
+/*
+  
+  This example shows how to get single conversions out of the ADS1220.
+  Tested with a ADS1120 but should work with the ADS1220 too.
+  Felipe Navarro 17/09/2017
+  
+*/
+
+#include "ADS1220.h"
+
+ADS1220 adc;
+
+void setup() {
+  Serial.begin(115200);
+
+  adc.begin(8,7);
+  
+  adc.setGain(1); //Set gain is a little buggie with ADS1120, doesn't have a ADS1220 to test out
+  adc.setDataRate(0x00);  
+  adc.setOpMode(0x00);
+  adc.setConversionMode(0x01); //This enables Single Conversion modes
+  adc.setMultiplexer(0x00);
+
+}
+
+void loop() {
+    long test = adc.readADC_Single();
+    Serial.println(test); 
+}

--- a/src/ADS1220.cpp
+++ b/src/ADS1220.cpp
@@ -74,6 +74,67 @@ long ADS1220::readADC() {
   return adcVal;
 }
 
+byte * ADS1220::readADC_Array() {
+  digitalWrite(ADS1220_CS_PIN, LOW); // Take CS low
+  delayMicroseconds(1); // Minimum of td(CSSC)
+  static byte dataarray[3];
+  for (int x = 0; x < 3 ; x++)
+  {
+    dataarray[x] = SPI.transfer(SPI_MASTER_DUMMY);
+  }
+  delayMicroseconds(1); // Minimum of td(CSSC)
+  digitalWrite(ADS1220_CS_PIN, HIGH);
+  return dataarray;
+}
+
+//Single Conversion read modes
+long ADS1220::readADC_Single() {
+  digitalWrite(ADS1220_CS_PIN, LOW); // Take CS low
+  delayMicroseconds(1); // Minimum of td(CSSC)
+
+  SPI.transfer(0x08);
+  while(digitalRead(ADS1220_DRDY_PIN) == HIGH)
+  {
+    //Wait to DRDY goes down
+    //Not a good thing
+    //Code could be stuck here
+    //Need a improve later
+  }
+  
+  long adcVal = SPI.transfer(SPI_MASTER_DUMMY);
+  adcVal = (adcVal << 8) | SPI.transfer(SPI_MASTER_DUMMY);
+  adcVal = (adcVal << 8) | SPI.transfer(SPI_MASTER_DUMMY);
+
+  adcVal = ( adcVal << 8 );
+  adcVal = ( adcVal >> 8 );
+  delayMicroseconds(1); // Minimum of td(CSSC)
+  digitalWrite(ADS1220_CS_PIN, HIGH);
+  return adcVal;
+}
+
+byte * ADS1220::readADC_SingleArray() {
+  digitalWrite(ADS1220_CS_PIN, LOW); // Take CS low
+  delayMicroseconds(1); // Minimum of td(CSSC)
+
+  SPI.transfer(0x08);
+  while(digitalRead(ADS1220_DRDY_PIN) == HIGH)
+  {
+    //Wait to DRDY goes down
+    //Not a good thing
+    //Code could be stuck here
+    //Need a improve later
+  }
+
+  static byte dataarray[3];
+  for (int x = 0; x < 3 ; x++)
+  {
+    dataarray[x] = SPI.transfer(SPI_MASTER_DUMMY);
+  }
+  delayMicroseconds(1); // Minimum of td(CSSC)
+  digitalWrite(ADS1220_CS_PIN, HIGH);
+  return dataarray;
+}
+
 void ADS1220::sendCommand(uint8_t command) {
   // Following Protocentral's code, not sure exactly what's going on here.
   digitalWrite(ADS1220_CS_PIN, LOW);

--- a/src/ADS1220.h
+++ b/src/ADS1220.h
@@ -54,6 +54,8 @@ class ADS1220 {
     bool isDataReady(void);
     long readADC(void);
     byte * readADC_Array(void);
+    long readADC_Single(void);
+    byte * readADC_SingleArray(void);
     void sendCommand(uint8_t command);
     void reset(void);
     void startSync(void);

--- a/src/ADS1220.h
+++ b/src/ADS1220.h
@@ -53,6 +53,7 @@ class ADS1220 {
     void begin(uint8_t cs_pin, uint8_t drdy_pin);
     bool isDataReady(void);
     long readADC(void);
+    byte * readADC_Array(void);
     void sendCommand(uint8_t command);
     void reset(void);
     void startSync(void);


### PR DESCRIPTION
I was trying to get Single Conversion working, but it couldn't work because of the way the code was written.

Digging into the datasheet, I found into Figure 63 of the ADS1120 datasheet that the CS needs to stay low while trying to get Single Conversion data. I implemented it.

Also added a int pointer array return for getting raw data out of the ADS1220/ADS1120 when you needs to send raw data over serial/wireless/etc comm channels.